### PR TITLE
Fix missing parentheses in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Unbox a boxed JS primitive value. This module works cross-realm/iframe, does not
 var unboxPrimitive = require('unbox-primitive');
 var assert = require('assert');
 
-assert.equal(unboxPrimitive(new Boolean(false), false);
-assert.equal(unboxPrimitive(new String('f'), 'f');
-assert.equal(unboxPrimitive(new Number(42), 42);
+assert.equal(unboxPrimitive(new Boolean(false)), false);
+assert.equal(unboxPrimitive(new String('f')), 'f');
+assert.equal(unboxPrimitive(new Number(42)), 42);
 const s = Symbol();
-assert.equal(unboxPrimitive(Object(s), s);
-assert.equal(unboxPrimitive(new BigInt(42), 42n);
+assert.equal(unboxPrimitive(Object(s)), s);
+assert.equal(unboxPrimitive(new BigInt(42)), 42n);
 
 // any primitive, or non-boxed-primitive object, will throw
 ```


### PR DESCRIPTION
Just fixes a few small typos in the README

```
> assert.equal(unboxPrimitive(new Boolean(false), false);
assert.equal(unboxPrimitive(new Boolean(false), false);
                                                     ^

SyntaxError: missing ) after argument list
```